### PR TITLE
oAuthDomains can be a list of domains, separated by comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,4 @@ sonar.auth.googleoauth.clientId.secured    |Consumer Key provided by Google when
 sonar.auth.googleoauth.clientSecret.secured|Consumer password provided by Google when registering the consumer|None
 sonar.auth.googleoauth.enabled             |Enable Google users to login. Value is ignored if consumer Key and Secret are not defined|false
 sonar.auth.googleoauth.loginStrategy       |When the login strategy is set to 'Unique', the user's login will be auto-generated the first time so that it is unique. When the login strategy is set to 'Same as Google login', the user's login will be the Google login. This last strategy allows, when changing the authentication provider, to keep existing users (if logins from new provider are the same than Google)|Unique
-sonar.auth.googleoauth.limitOauthDomain    |When set with a GApps domain, only allow users from that domain to authenticate|None
-
-
-
-
-
-
+sonar.auth.googleoauth.limitOauthDomain    |When set with a GApps domain, only allow users from that domain to authenticate. Can be a list by separating domains with ","|None

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.sonarqube.auth.google</groupId>
   <artifactId>sonar-auth-googleoauth-plugin</artifactId>
-  <version>1.6.3-SNAPSHOT</version>
+  <version>1.6.4-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
   <name>Google Authentication for SonarQube</name>
   <inceptionYear>2016</inceptionYear>

--- a/src/main/java/org/sonarqube/auth/googleoauth/GoogleIdentityProvider.java
+++ b/src/main/java/org/sonarqube/auth/googleoauth/GoogleIdentityProvider.java
@@ -55,6 +55,8 @@ import java.io.IOException;
 
 import java.net.URL;
 import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.Optional;
 
 import static java.lang.String.format;
 
@@ -124,9 +126,9 @@ public class GoogleIdentityProvider implements OAuth2IdentityProvider {
 
     GsonUser gsonUser = requestUser(scribe, accessToken);
     String redirectTo;
-    if (settings.oauthDomain()==null || (settings.oauthDomain()!=null && gsonUser.getEmail().endsWith("@"+settings.oauthDomain()))) {
+    if (settings.oauthDomain()==null || (checkValidDomain(settings.oauthDomain(), gsonUser.getEmail()))) {
         redirectTo = settings.getSonarBaseURL();
-		String referer_url = request.getHeader("referer");
+        String referer_url = request.getHeader("referer");
         try {
             URL urlObj = new URL(referer_url);
             String returnToValue = null;
@@ -154,6 +156,10 @@ public class GoogleIdentityProvider implements OAuth2IdentityProvider {
     } catch (IOException ioe) {
       throw MessageException.of("Unable to redirect after OAuth login", ioe);
     }
+  }
+
+  private Boolean checkValidDomain(String oAuthDomains, String userEmail) {
+    return Arrays.stream(oAuthDomains.split(",")).anyMatch((domain) -> userEmail.endsWith("@" + domain));
   }
 
   private GsonUser requestUser(OAuthService scribe, Token accessToken) {

--- a/src/main/java/org/sonarqube/auth/googleoauth/GoogleIdentityProvider.java
+++ b/src/main/java/org/sonarqube/auth/googleoauth/GoogleIdentityProvider.java
@@ -55,8 +55,6 @@ import java.io.IOException;
 
 import java.net.URL;
 import java.net.URLDecoder;
-import java.util.Arrays;
-import java.util.Optional;
 
 import static java.lang.String.format;
 
@@ -159,7 +157,12 @@ public class GoogleIdentityProvider implements OAuth2IdentityProvider {
   }
 
   private Boolean checkValidDomain(String oAuthDomains, String userEmail) {
-    return Arrays.stream(oAuthDomains.split(",")).anyMatch((domain) -> userEmail.endsWith("@" + domain));
+    for (String domain : oAuthDomains.split(",")) {
+      if (userEmail.trim().endsWith("@" + domain.trim())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private GsonUser requestUser(OAuthService scribe, Token accessToken) {

--- a/src/main/java/org/sonarqube/auth/googleoauth/GoogleScribeApi.java
+++ b/src/main/java/org/sonarqube/auth/googleoauth/GoogleScribeApi.java
@@ -75,7 +75,7 @@ public class GoogleScribeApi extends GoogleApi20 {
     if(state != null) {
       sb.append('&').append("state").append('=').append(OAuthEncoder.encode(state));
     }
-    if (settings.oauthDomain() != null) {
+    if (settings.oauthDomain() != null && !settings.oauthDomain().contains(",")) {
       sb.append('&').append("hd=").append(settings.oauthDomain());
     }
 


### PR DESCRIPTION
Hey,
we needed to have a list of domains to whitelist, I added the doc and extended the domain check a bit. Unfortunately this doesn't work for the [hd OAuth parameter](https://developers.google.com/identity/protocols/OpenIDConnect#hd-param) (which limits the UI part on Google to your whitelisted domain).